### PR TITLE
Make QgsCurvePolygonV2::nextVertex return all vertices, have QgsGeometryUtils::closestVertex prefer returning closing vertices

### DIFF
--- a/src/core/geometry/qgscurvepolygonv2.cpp
+++ b/src/core/geometry/qgscurvepolygonv2.cpp
@@ -551,18 +551,6 @@ bool QgsCurvePolygonV2::nextVertex( QgsVertexId& vId, QgsPointV2& vertex ) const
   {
     QgsCurveV2* ring = vId.ring == 0 ? mExteriorRing : mInteriorRings[vId.ring - 1];
 
-    // Skip the closing vertex of the ring (which is equal to the first one)
-    if ( vId.vertex == ring->numPoints() - 2 )
-    {
-      ++vId.ring;
-      vId.vertex = -1;
-      if ( vId.ring >= 1 + mInteriorRings.size() )
-      {
-        return false;
-      }
-      ring = mInteriorRings[ vId.ring - 1 ];
-    }
-
     if ( ring->nextVertex( vId, vertex ) )
     {
       return true;

--- a/src/core/geometry/qgscurvepolygonv2.h
+++ b/src/core/geometry/qgscurvepolygonv2.h
@@ -78,7 +78,6 @@ class QgsCurvePolygonV2: public QgsSurfaceV2
 
     virtual void coordinateSequence( QList< QList< QList< QgsPointV2 > > >& coord ) const;
     double closestSegment( const QgsPointV2& pt, QgsPointV2& segmentPt,  QgsVertexId& vertexAfter, bool* leftOf, double epsilon ) const;
-    /** Note: this method skips the closing vertices of the polygon rings */
     bool nextVertex( QgsVertexId& id, QgsPointV2& vertex ) const;
 
   protected:

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -28,7 +28,12 @@ QgsPointV2 QgsGeometryUtils::closestVertex( const QgsAbstractGeometryV2& geom, c
   while ( geom.nextVertex( vertexId, vertex ) )
   {
     currentDist = QgsGeometryUtils::sqrDistance2D( pt, vertex );
-    if ( currentDist < minDist )
+    // The <= is on purpose: for geometries with closing vertices, this ensures
+    // that the closing vertex is retuned. For the node tool, the rubberband
+    // of the closing vertex is above the opening vertex, hence with the <=
+    // situations where the covered opening vertex rubberband is selected are
+    // avoided.
+    if ( currentDist <= minDist )
     {
       minDist = currentDist;
       minDistPoint = vertex;


### PR DESCRIPTION
Hmm somewhat hacky aber eigentlich doch halbwegs elegant, was meinst?:)
